### PR TITLE
chore(deps): bump google-github-actions/setup-gcloud from 0 to 1 

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -11,10 +11,12 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCP_KEY_CONTAINER_REGISTRY }}
+      - uses: google-github-actions/setup-gcloud@v1
         with:
           version: '372.0.0'
-          service_account_key: ${{ secrets.GCP_KEY_CONTAINER_REGISTRY }}
       - run: gcloud auth configure-docker
       - run: yarn --immutable --immutable-cache
       - run: yarn push-image

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,5 +1,6 @@
 name: Image
 on:
+  pull_request:
   push:
     branches:
       - main
@@ -19,4 +20,4 @@ jobs:
           version: '372.0.0'
       - run: gcloud auth configure-docker
       - run: yarn --immutable --immutable-cache
-      - run: yarn push-image
+#      - run: yarn push-image


### PR DESCRIPTION
Additionally, update Google Cloud Authentication Method, since the `service_account_key` input has been deprecated, and the `google-github-actions/auth` action needs to be used now for authentication to Google Cloud (reference: https://github.com/google-github-actions/setup-gcloud#service-account-key-json).