### PR TITLE
fix(dependabot): remove Cloud SDK version that might be old so that it takes default latest

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -13,10 +13,8 @@ jobs:
           node-version: 18.x
       - uses: google-github-actions/auth@v1
         with:
-          credentials_json: ${{ secrets.GCP_KEY_CONTAINER_REGISTRY }}
+          credentials_json: '${{ secrets.GCP_KEY_CONTAINER_REGISTRY }}'
       - uses: google-github-actions/setup-gcloud@v1
-        with:
-          version: '372.0.0'
       - run: gcloud auth configure-docker
       - run: yarn --immutable --immutable-cache
       - run: yarn push-image


### PR DESCRIPTION
This PR takes the commit 7830c27ff6cb2c589bf72b522be77c4d670a3c94 from https://github.com/serlo/db-migrations/pull/25 to refactor a bit the usage of the `google-github-actions` ✨ 

