### PR TITLE
chore(github-actions): Update the Docker workflow for PR events

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,9 +2,18 @@ name: Docker
 on:
   pull_request:
   merge_group:
+env:
+  PR_NUMBER: ${{ github.event.number }}
 jobs:
-  migrate:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: docker build . -t api-db-migration:latest
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build the api-db-migration image
+        uses: docker/build-push-action@v4
+        with:
+          push: false
+          file: ./Dockerfile
+          tags: api-db-migration:PR-${{ env.PR_NUMBER }}


### PR DESCRIPTION
To rename the job (`migrate` -> `build`), use the `docker/build-push-action` action instead, and use a tag that correspond to the pull request number.