### PR TITLE
Use cache input of the setup-node action 

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
+          cache: 'yarn'
       - uses: google-github-actions/auth@v1
         with:
           credentials_json: '${{ secrets.GCP_KEY_CONTAINER_REGISTRY }}'

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -17,5 +17,5 @@ jobs:
           credentials_json: '${{ secrets.GCP_KEY_CONTAINER_REGISTRY }}'
       - uses: google-github-actions/setup-gcloud@v1
       - run: gcloud auth configure-docker
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --check-cache
       - run: yarn push-image

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: 18.x
           cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --check-cache
       - run: yarn lint:prettier
   test:
     runs-on: ubuntu-latest
@@ -24,5 +24,5 @@ jobs:
         with:
           node-version: 18.x
           cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --check-cache
       - run: yarn test

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
+          cache: 'yarn'
       - run: yarn --immutable --immutable-cache
       - run: yarn lint:prettier
   test:
@@ -22,5 +23,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
+          cache: 'yarn'
       - run: yarn --immutable --immutable-cache
       - run: yarn test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM node:18-alpine as dependencies
+FROM node:18-alpine AS dependencies
 WORKDIR /usr/src/app
-# COPY .yarn .yarn
 COPY package.json .
 COPY yarn.lock .
-RUN yarn --silent
+RUN yarn --immutable --immutable-cache --check-cache
 
 FROM dependencies
 COPY dist migrations


### PR DESCRIPTION
To cache dependencies (reduce GitHub Actions workflows execution time).

Additionally:
* Add the `--check-cache` option in `yarn` commands. 
* Update the `Dockerfile` to use the same `yarn` options used in the GitHub Actions workflows.