### PR TITLE
chore(github_actions): Use the cache input in the setup-node action

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
+          cache: 'yarn'
       - uses: google-github-actions/auth@v1
         with:
           credentials_json: '${{ secrets.GCP_KEY_CONTAINER_REGISTRY }}'

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -17,5 +17,5 @@ jobs:
           credentials_json: '${{ secrets.GCP_KEY_CONTAINER_REGISTRY }}'
       - uses: google-github-actions/setup-gcloud@v1
       - run: gcloud auth configure-docker
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --check-cache
       - run: yarn push-image

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: 18.x
           cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --check-cache
       - run: yarn lint:prettier
   test:
     runs-on: ubuntu-latest
@@ -24,5 +24,5 @@ jobs:
         with:
           node-version: 18.x
           cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable --immutable-cache --check-cache
       - run: yarn test

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
+          cache: 'yarn'
       - run: yarn --immutable --immutable-cache
       - run: yarn lint:prettier
   test:
@@ -22,5 +23,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
+          cache: 'yarn'
       - run: yarn --immutable --immutable-cache
       - run: yarn test


### PR DESCRIPTION
To reduce the GitHub Actions workflows execution times ✨ 

Additionally, add the `--check-cache` option in yarn commands to always refetch the packages and ensure that their checksums are consistent.