### PR TITLE
chore(yarn): Add "yarn format" and "yarn lint"

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "_prettier": "prettier . '!dist/**/*'",
     "build": "ts-node scripts/build",
+    "format": "yarn format:prettier",
     "format:prettier": "yarn _prettier --write",
+    "lint": "yarn lint:prettier",
     "lint:prettier": "yarn _prettier --check",
     "m": "yarn migrate:ts",
     "migrate:docker": "docker compose run --build --rm server-migrate",


### PR DESCRIPTION
For now this is a shortcut to `yarn format:prettier` and `yarn lint:prettier`. In another PR I try to add support for `eslint` and `tsc` as well... 