### PR TITLE
chore: Add "yarn migrate:run"

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ You can start a local version of the mysql database via `yarn start`. There are
 the following helper functions:
 
 - `yarn mysql` – Open a shell to MySQL
+- `yarn migrate:run [path]` – Run a certain migration (like
+  `yarn migrate:run src/20201023104526-update-subjects.ts`)
 - `yarn mysql:rollback` – Rollback database before any applied migrations
 - `yarn mysql:list-migrations` – List all migrations which have been already run
 - `yarn migrate:ts` – Run all migrations directly from `src` directory (no build

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint:prettier": "yarn _prettier --check",
     "lint:tsc": "tsc --noEmit --project tsconfig.json",
     "migrate:docker": "docker compose run --build --rm server-migrate",
+    "migrate:run": "scripts/run_migrations.sh",
     "migrate:ts": "npm-run-all build:cache migrate:build-cache",
     "migrate:build-cache": "DATABASE=mysql://root:secret@localhost:3306/serlo yarn db-migrate -m dist up",
     "mysql": "docker compose exec mysql serlo-mysql",

--- a/scripts/run_migrations.sh
+++ b/scripts/run_migrations.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+export BUILD_OUTDIR=dist
+
+main() {
+  clear_build_outdir
+  build_migrations_into_build_outdir "$@"
+  delete_migrations_in_mysql "$@"
+  run_migrations_in_build_outdir
+}
+
+clear_build_outdir() {
+  if ls $BUILD_OUTDIR/*js &> /dev/null; then
+    rm $BUILD_OUTDIR/*js
+  fi
+}
+
+build_migrations_into_build_outdir() {
+  yarn build "$@"
+}
+
+delete_migrations_in_mysql() {
+  FIRST=true
+
+  for ARG in "$@"; do
+    if [ "$FIRST" = "true" ]; then
+      FIRST=false
+    else
+      MIGRATIONS="${MIGRATIONS}, "
+    fi
+
+    FILENAME="$(basename "$ARG")"
+    MIGRATIONS="\"/${FILENAME%.*}\""
+  done
+
+  yarn mysql --execute "DELETE FROM migrations WHERE name IN ($MIGRATIONS)"
+}
+
+run_migrations_in_build_outdir() {
+  yarn migrate:build-cache
+}
+
+main "$@"


### PR DESCRIPTION
Helpful for https://github.com/serlo/db-migrations/pull/96: This makes it possible to run exactly one or more passed migrations