### PR TITLE
test(github): Don't run all migrations in tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -38,7 +38,6 @@ jobs:
       - uses: serlo/configure-repositories/actions/setup-node@main
       - run: yarn start
       - uses: serlo/configure-repositories/actions/setup-mysql@main
-      - run: yarn mysql:delete-all-migrations:ci
       - run: yarn migrate:ts
       - uses: ./.github/actions/test-migrations
 
@@ -50,6 +49,5 @@ jobs:
       - uses: serlo/configure-repositories/actions/setup-node@main
       - run: yarn start
       - uses: serlo/configure-repositories/actions/setup-mysql@main
-      - run: yarn mysql:delete-all-migrations:ci
       - run: yarn migrate:docker
       - uses: ./.github/actions/test-migrations

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "mysql:ci": "docker compose exec mysql serlo-mysql",
     "mysql:delete-last-migration": "yarn mysql --execute 'DELETE FROM migrations ORDER BY id DESC LIMIT 1'",
     "mysql:delete-all-migrations": "yarn mysql --execute 'DELETE FROM migrations'",
-    "mysql:delete-all-migrations:ci": "yarn mysql:ci --execute 'DELETE FROM migrations'",
     "mysql:import-anonymous-data": "ts-node --experimental-specifier-resolution=node scripts/mysql/mysql-import-anonymous-data",
     "mysql:list-migrations": "yarn mysql --execute 'SELECT * FROM migrations'",
     "mysql:list-migrations:ci": "yarn mysql:ci --execute 'SELECT * FROM migrations'",


### PR DESCRIPTION
Otherwise we get errors for migrations which are not idempotent in their implementation.

Current error:

```
2023-10-23T07:49:39.9577609Z [ERROR] AssertionError [ERR_ASSERTION]: ifError got unwanted exception: Duplicate column name 'original_author_url'
2023-10-23T07:49:39.9579706Z     at /home/runner/work/db-migrations/db-migrations/node_modules/db-migrate/lib/commands/on-complete.js:15:14
2023-10-23T07:49:39.9581561Z     at tryCatcher (/home/runner/work/db-migrations/db-migrations/node_modules/bluebird/js/release/util.js:16:23)
2023-10-23T07:49:39.9584755Z     at Promise.successAdapter (/home/runner/work/db-migrations/db-migrations/node_modules/bluebird/js/release/nodeify.js:22:30)
2023-10-23T07:49:39.9586988Z     at Promise._settlePromise (/home/runner/work/db-migrations/db-migrations/node_modules/bluebird/js/release/promise.js:601:21)
2023-10-23T07:49:39.9637984Z     at Promise._settlePromiseCtx (/home/runner/work/db-migrations/db-migrations/node_modules/bluebird/js/release/promise.js:641:10)
2023-10-23T07:49:39.9640245Z     at _drainQueueStep (/home/runner/work/db-migrations/db-migrations/node_modules/bluebird/js/release/async.js:97:12)
2023-10-23T07:49:39.9642126Z     at _drainQueue (/home/runner/work/db-migrations/db-migrations/node_modules/bluebird/js/release/async.js:86:9)
2023-10-23T07:49:39.9643866Z     at Async._drainQueues (/home/runner/work/db-migrations/db-migrations/node_modules/bluebird/js/release/async.js:102:5)
2023-10-23T07:49:39.9645784Z     at Async.drainQueues [as _onImmediate] (/home/runner/work/db-migrations/db-migrations/node_modules/bluebird/js/release/async.js:15:14)
2023-10-23T07:49:39.9647135Z     at process.processImmediate (node:internal/timers:476:21)
2023-10-23T07:49:39.9648512Z     at Packet.asError (/home/runner/work/db-migrations/db-migrations/node_modules/mysql2/lib/packets/packet.js:728:17)
2023-10-23T07:49:39.9650312Z     at Query.execute (/home/runner/work/db-migrations/db-migrations/node_modules/mysql2/lib/commands/command.js:29:26)
2023-10-23T07:49:39.9652116Z     at Connection.handlePacket (/home/runner/work/db-migrations/db-migrations/node_modules/mysql2/lib/connection.js:456:32)
2023-10-23T07:49:39.9653938Z     at PacketParser.onPacket (/home/runner/work/db-migrations/db-migrations/node_modules/mysql2/lib/connection.js:85:12)
2023-10-23T07:49:39.9655812Z     at PacketParser.executeStart (/home/runner/work/db-migrations/db-migrations/node_modules/mysql2/lib/packet_parser.js:75:16)
2023-10-23T07:49:39.9657601Z     at Socket.<anonymous> (/home/runner/work/db-migrations/db-migrations/node_modules/mysql2/lib/connection.js:92:25)
2023-10-23T07:49:39.9658656Z     at Socket.emit (node:events:513:28)
2023-10-23T07:49:39.9659289Z     at addChunk (node:internal/streams/readable:324:12)
2023-10-23T07:49:39.9660067Z     at readableAddChunk (node:internal/streams/readable:297:9)
2023-10-23T07:49:39.9660869Z     at Readable.push (node:internal/streams/readable:234:10)
2023-10-23T07:49:39.9662007Z     at TCP.onStreamRead (node:internal/stream_base_commons:190:23)
2023-10-23T07:49:40.0480108Z ERROR: "migrate:up:dist" exited with 1.
```