### PR TITLE
fix(scripts): outdated yarn _build command

### DIFF
--- a/scripts/run_migrations.sh
+++ b/scripts/run_migrations.sh
@@ -16,7 +16,7 @@ clear_build_outdir() {
 }
 
 build_migrations_into_build_outdir() {
-  yarn _build "$@"
+  yarn build "$@"
 }
 
 delete_migrations_in_mysql() {


### PR DESCRIPTION
The `_build` is now `build` after [this change](https://github.com/serlo/db-migrations/pull/300/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R10)