### PR TITLE
fix(redis): Delete keys at the end of the migration

### DIFF
--- a/__tests__/redis.ts
+++ b/__tests__/redis.ts
@@ -7,20 +7,20 @@ const apiCache = new ApiCache()
 
 afterAll(async () => {
   await redis.quit()
-  await apiCache.quit()
+  await apiCache.deleteKeysAndQuit()
 })
 
 describe('deleteUuid', () => {
   test('deletes uuid key', async () => {
     await redis.set('de.serlo.org/api/uuid/1', 'hello')
 
-    await apiCache.deleteUuid(1)
+    await apiCache.markUuid(1)
 
     expect(await redis.get('de.serlo.org/api/uuid/1')).toBeNull()
   })
 
   test('does not throw an error when key is not present', async () => {
-    await apiCache.deleteUuid(42)
+    await apiCache.markUuid(42)
 
     expect(await redis.get('de.serlo.org/api/uuid/42')).toBeNull()
   })

--- a/__tests__/redis.ts
+++ b/__tests__/redis.ts
@@ -3,24 +3,29 @@ import Redis from 'ioredis'
 import { ApiCache } from '../src/utils/api-cache'
 
 const redis = new Redis(process.env.REDIS_URL as string)
-const apiCache = new ApiCache()
+let apiCache: ApiCache
+
+beforeEach(() => {
+  apiCache = new ApiCache()
+})
 
 afterAll(async () => {
   await redis.quit()
-  await apiCache.deleteKeysAndQuit()
 })
 
 describe('deleteUuid', () => {
   test('deletes uuid key', async () => {
     await redis.set('de.serlo.org/api/uuid/1', 'hello')
 
-    await apiCache.markUuid(1)
+    apiCache.markUuid(1)
+    await apiCache.deleteKeysAndQuit()
 
     expect(await redis.get('de.serlo.org/api/uuid/1')).toBeNull()
   })
 
   test('does not throw an error when key is not present', async () => {
-    await apiCache.markUuid(42)
+    apiCache.markUuid(42)
+    await apiCache.deleteKeysAndQuit()
 
     expect(await redis.get('de.serlo.org/api/uuid/42')).toBeNull()
   })

--- a/src/20240205193700-merge-grouped-exercise-into-exercise-group.ts
+++ b/src/20240205193700-merge-grouped-exercise-into-exercise-group.ts
@@ -31,7 +31,7 @@ const OldExercisePluginDecoder = t.type({
 
 createMigration(exports, {
   up: async (db) => {
-    const apiCache = new ApiCache({ enableLogging: false })
+    const apiCache = new ApiCache()
     const logger = new SlackLogger(
       'merge-grouped-exercises-into-exercise-groups',
     )
@@ -59,7 +59,7 @@ createMigration(exports, {
       }
     } while (entities.length > 0)
 
-    await apiCache.deleteUnrevisedRevisions()
+    apiCache.deleteUnrevisedRevisions()
     await apiCache.deleteKeysAndQuit()
     await logger.closeAndSend()
 

--- a/src/20240205193700-merge-grouped-exercise-into-exercise-group.ts
+++ b/src/20240205193700-merge-grouped-exercise-into-exercise-group.ts
@@ -60,7 +60,7 @@ createMigration(exports, {
     } while (entities.length > 0)
 
     await apiCache.deleteUnrevisedRevisions()
-    await apiCache.quit()
+    await apiCache.deleteKeysAndQuit()
     await logger.closeAndSend()
 
     interface Row {
@@ -236,7 +236,7 @@ async function updateExerciseGroup(
         newContent,
       })
 
-      await apiCache.deleteUuid(edit.value.revision.id)
+      await apiCache.markUuid(edit.value.revision.id)
     } else {
       // In this edit the parent was not changed -> Let's use the revision
       // of one changed child and change it to a revision of the parent
@@ -279,7 +279,7 @@ async function updateExerciseGroup(
             logger,
           })
 
-          await apiCache.deleteUuid(child.value.id)
+          await apiCache.markUuid(child.value.id)
         }
       }
 
@@ -296,11 +296,11 @@ async function updateExerciseGroup(
         newContent,
       })
 
-      await apiCache.deleteUuid(revisionToOvertake.revision.id)
+      await apiCache.markUuid(revisionToOvertake.revision.id)
     }
   }
 
-  await apiCache.deleteUuid(parentNode.value.id)
+  await apiCache.markUuid(parentNode.value.id)
 
   for (const child of parentNode.children) {
     await moveCommentsFromChildToParent({
@@ -310,7 +310,7 @@ async function updateExerciseGroup(
       child: child.value,
     })
 
-    await apiCache.deleteUuid(child.value.id)
+    await apiCache.markUuid(child.value.id)
   }
 }
 
@@ -345,7 +345,7 @@ async function updateCurrentRevisionOfEntity({
       },
     })
 
-    await apiCache.deleteUuid(parent.id)
+    await apiCache.markUuid(parent.id)
   }
 }
 
@@ -372,7 +372,7 @@ async function moveCommentsFromChildToParent({
   )
 
   for (const comment of commentsOfSolution) {
-    await apiCache.deleteUuid(comment.id)
+    await apiCache.markUuid(comment.id)
   }
 
   await apiCache.deleteThreadIds(parent.id)

--- a/src/20240217173500-remove-injections-of-nonexisting-uuids.ts
+++ b/src/20240217173500-remove-injections-of-nonexisting-uuids.ts
@@ -45,6 +45,6 @@ createMigration(exports, {
       }),
     })
 
-    await apiCache.quit()
+    await apiCache.deleteKeysAndQuit()
   },
 })

--- a/src/20240217181500-migrate-injections-of-grouped-exercises.ts
+++ b/src/20240217181500-migrate-injections-of-grouped-exercises.ts
@@ -79,6 +79,6 @@ createMigration(exports, {
       }),
     })
 
-    await apiCache.quit()
+    await apiCache.deleteKeysAndQuit()
   },
 })

--- a/src/utils/api-cache.ts
+++ b/src/utils/api-cache.ts
@@ -3,10 +3,8 @@ import Redis from 'ioredis'
 export class ApiCache {
   private keys: Set<string>
   private redis: Redis
-  private enableLogging: boolean
 
-  constructor(args?: { enableLogging?: boolean }) {
-    this.enableLogging = args?.enableLogging ?? false
+  constructor() {
     this.keys = new Set()
 
     if (typeof process.env.REDIS_URL === 'string') {
@@ -38,10 +36,6 @@ export class ApiCache {
 
   public markUuid(uuid: number) {
     this.markKey(`de.serlo.org/api/uuid/${uuid}`)
-
-    if (this.enableLogging) {
-      console.log(`INFO: API cache for UUID ${uuid} deleted`)
-    }
   }
 
   public async deleteKeysAndQuit() {

--- a/src/utils/api-cache.ts
+++ b/src/utils/api-cache.ts
@@ -39,7 +39,9 @@ export class ApiCache {
   }
 
   public async deleteKeysAndQuit() {
-    await this.redis.del(...this.keys)
+    if (this.keys.size > 0) {
+      await this.redis.del(Array.from(this.keys))
+    }
     await this.redis.quit()
   }
 

--- a/src/utils/api-cache.ts
+++ b/src/utils/api-cache.ts
@@ -1,11 +1,13 @@
 import Redis from 'ioredis'
 
 export class ApiCache {
+  private keys: Set<string>
   private redis: Redis
   private enableLogging: boolean
 
   constructor(args?: { enableLogging?: boolean }) {
     this.enableLogging = args?.enableLogging ?? false
+    this.keys = new Set()
 
     if (typeof process.env.REDIS_URL === 'string') {
       this.redis = new Redis(process.env.REDIS_URL)
@@ -14,35 +16,40 @@ export class ApiCache {
     }
   }
 
-  public async quit() {
-    await this.redis.quit()
+  public deleteUnrevisedRevisions() {
+    this.markKey('serlo.org/unrevised')
   }
 
-  public async deleteUnrevisedRevisions() {
-    await this.redis.del('serlo.org/unrevised')
+  public deleteThreadIds(uuid: number) {
+    this.markKey(`de.serlo.org/api/threads/${uuid}`)
   }
 
-  public async deleteThreadIds(uuid: number) {
-    await this.redis.del(`de.serlo.org/api/threads/${uuid}`)
+  public markEvent(eventId: number) {
+    this.markKey(`de.serlo.org/api/event/${eventId}`)
   }
 
-  public async deleteEvent(eventId: number) {
-    await this.redis.del(`de.serlo.org/api/event/${eventId}`)
-  }
-
-  public async deleteAllNotifications() {
+  public async markAllNotifications() {
     const keys = await this.redis.keys('de.serlo.org/api/notifications/*')
 
     for (const key of keys) {
-      await this.redis.del(key)
+      this.keys.add(key)
     }
   }
 
-  public async deleteUuid(uuid: number) {
-    await this.redis.del(`de.serlo.org/api/uuid/${uuid}`)
+  public markUuid(uuid: number) {
+    this.markKey(`de.serlo.org/api/uuid/${uuid}`)
 
     if (this.enableLogging) {
       console.log(`INFO: API cache for UUID ${uuid} deleted`)
     }
+  }
+
+  public async deleteKeysAndQuit() {
+    await this.redis.del(...this.keys)
+    await this.redis.quit()
+  }
+
+  private markKey(key: string) {
+    this.keys.add(key)
   }
 }

--- a/src/utils/api-cache.ts
+++ b/src/utils/api-cache.ts
@@ -1,5 +1,4 @@
 import Redis from 'ioredis'
-import { SlackLogger } from './slack-logger'
 
 export class ApiCache {
   private redis: Redis

--- a/src/utils/create-migration.ts
+++ b/src/utils/create-migration.ts
@@ -56,7 +56,7 @@ export function createEdtrIoMigration({
 
       await migrateSerloEditorContent({ ...otherArgs, apiCache, db })
 
-      await apiCache.quit()
+      await apiCache.deleteKeysAndQuit()
     },
   })
 }
@@ -213,7 +213,7 @@ async function changeUuidContents({
             newContent,
             uuid.id,
           )
-          await apiCache.deleteUuid(uuid.uuid)
+          await apiCache.markUuid(uuid.uuid)
         }
 
         log(`Update ${table}.${column} with ID ${uuid.uuid}`)

--- a/src/utils/delete-utils.ts
+++ b/src/utils/delete-utils.ts
@@ -23,7 +23,7 @@ export async function deleteUuids(
     await db.runSql(`DELETE FROM uuid WHERE id IN ${toSqlTuple(uuids)}`)
 
     for (const id of uuids) {
-      await apiCache.deleteUuid(id)
+      await apiCache.markUuid(id)
     }
 
     // Make sure that events are also deleted from DB and ApiCache
@@ -42,9 +42,9 @@ export async function deleteEventLogs(
     await db.runSql(`DELETE FROM event_log WHERE id IN ${toSqlTuple(ids)}`)
 
     for (const eventId of ids) {
-      await apiCache.deleteEvent(eventId)
+      await apiCache.markEvent(eventId)
     }
   }
 
-  await apiCache.deleteAllNotifications()
+  await apiCache.markAllNotifications()
 }


### PR DESCRIPTION
Today @elbotho and I ran into the following bug while doing the migration:

* The DB migration is a transaction and thus only live when the migrations ends
* Deleting api cache keys is done directly 
* While the migration took place (6min) some cache keys have been rewritten (since we haven't set serlo.org in maintenance mode) before the end of the migration
* We had bugs due to wrong cache values :sob: 

This PR has a first solution which is that the cache keys are deleted at the end of the migration => There is still a time between deleting the cache and finishing the DB transaction, however the time span is much smaller now