### PR TITLE
refactor: Remove createMigration()

### DIFF
--- a/src/20240304000000-delete-redirection-mathe-pruefungen.ts
+++ b/src/20240304000000-delete-redirection-mathe-pruefungen.ts
@@ -1,18 +1,17 @@
-import { createMigration } from './utils'
 import Redis from 'ioredis'
 
-createMigration(exports, {
-  up: async (db) => {
-    await db.runSql(`
+import { Database } from './utils'
+
+export async function up(db: Database) {
+  await db.runSql(`
       DELETE FROM url_alias WHERE alias = 'mathe-pruefungen'
       `)
 
-    if (typeof process.env.REDIS_URL === 'string') {
-      const redis = new Redis(process.env.REDIS_URL)
-      redis.del('de.serlo.org/api/alias/mathe-pruefungen')
-      redis.quit()
-    } else {
-      throw new Error('Env `REDIS_URL` is not defined')
-    }
-  },
-})
+  if (typeof process.env.REDIS_URL === 'string') {
+    const redis = new Redis(process.env.REDIS_URL)
+    redis.del('de.serlo.org/api/alias/mathe-pruefungen')
+    redis.quit()
+  } else {
+    throw new Error('Env `REDIS_URL` is not defined')
+  }
+}

--- a/src/utils/create-migration.ts
+++ b/src/utils/create-migration.ts
@@ -1,65 +1,7 @@
 import { ApiCache } from './api-cache'
-import { CallbackBasedDatabase, createDatabase, Database } from './database'
+import { Database } from './database'
 import { isPlugin } from './serlo-editor'
 import { SlackLogger } from './slack-logger'
-
-export function createMigration(
-  exports: any,
-  {
-    up,
-    down,
-  }: {
-    up: (db: Database) => Promise<void>
-    down?: (db: Database) => Promise<void>
-  },
-) {
-  exports._meta = {
-    version: 1,
-  }
-  exports.up = (db: CallbackBasedDatabase, cb: Callback) => {
-    up(createDatabase(db))
-      .then(() => {
-        cb(undefined)
-      })
-      .catch((error) => {
-        cb(error)
-      })
-  }
-  exports.down = (db: CallbackBasedDatabase, cb: Callback) => {
-    if (typeof down === 'function') {
-      down(createDatabase(db))
-        .then(() => {
-          cb()
-        })
-        .catch((error) => {
-          cb(error)
-        })
-    } else {
-      cb()
-    }
-  }
-}
-
-export function createSerloEditorMigration({
-  exports,
-  ...otherArgs
-}: {
-  exports: any
-  migrateState: (state: any) => any
-  dryRun?: boolean
-  migrationName?: string
-  log?: (message: string) => void
-}) {
-  createMigration(exports, {
-    up: async (db) => {
-      const apiCache = new ApiCache()
-
-      await migrateSerloEditorContent({ ...otherArgs, apiCache, db })
-
-      await apiCache.deleteKeysAndQuit()
-    },
-  })
-}
 
 export async function migrateSerloEditorContent({
   migrateState,

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -1,32 +1,3 @@
-export function createDatabase(db: CallbackBasedDatabase): Database {
-  return {
-    runSql: async <T>(query: string, ...params: unknown[]) => {
-      return new Promise<T>((resolve, reject) => {
-        db.runSql(query, ...params, (error: Error | undefined, results: T) => {
-          if (error) {
-            reject(error)
-            return
-          }
-          resolve(results)
-        })
-      })
-    },
-    dropTable: async (table: string) => {
-      return new Promise((resolve, reject) => {
-        db.dropTable(table, (error?: Error) => {
-          if (error) {
-            reject(error)
-            return
-          }
-          resolve()
-        })
-      })
-    },
-  }
-}
-
-export type CallbackBasedDatabase = any
-
 export interface Database {
   runSql: <T = void>(query: string, ...params: unknown[]) => Promise<T>
   dropTable: (table: string) => Promise<void>


### PR DESCRIPTION
I have noticed that after switching to `esbuild` we can directely export the `up` function via ESM `export`. It will be compiled to a `module.exports = { up }` as needed by db-migration library.