### PR TITLE
feat: Simplify taxonomy tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,10 @@ Example:
   when you want to migrate edtr-io plugins
 
 2. You need to build a migration by running
-`yarn build src/YYYYMMDDHHMMSS-xyz.ts` in the `src` directory. This creates a
-new file in `migrations`. Both files in `migrations` and `src` need to be added
-in the PR. _Notice that any changes in other directories that are imported by
-the file will be built together!_
-<!-- TODO: in conception still in the new infrastructure.
-   3. Update the version of the `serlo.org` server at
-   `packages/public/server/package.json`. Deploy this version with the changes
-   in the `migrations` package and the database migrations should take effect. -->
+   `yarn build src/YYYYMMDDHHMMSS-xyz.ts` in the `src` directory. This creates a
+   new file in `migrations`. Both files in `migrations` and `src` need to be
+   added in the PR. _Notice that any changes in other directories that are
+   imported by the file will be built together!_
 
 ## Test a new migration
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/server-migrate",
-  "version": "0.21.0",
+  "version": "0.22.0-staging.9",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/server-migrate",
-  "version": "1.0.0-staging.4",
+  "version": "1.0.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/server-migrate",
-  "version": "1.0.0-staging.1",
+  "version": "1.0.0-staging.2",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/server-migrate",
-  "version": "0.22.0-staging.9",
+  "version": "1.0.0-staging.1",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serlo/server-migrate",
-  "version": "1.0.0-staging.2",
+  "version": "1.0.0-staging.4",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/src/20240505020500-merge-entity_revision_field-into-entity_revision.ts
+++ b/src/20240505020500-merge-entity_revision_field-into-entity_revision.ts
@@ -1,0 +1,73 @@
+import { ApiCache, Database, SlackLogger } from './utils'
+
+export async function up(db: Database) {
+  const apiCache = new ApiCache()
+  const logger = new SlackLogger(
+    '20240505020500-merge-entity_revision_field-into-entity_revision',
+  )
+
+  console.log('start altering table')
+  await db.runSql(`ALTER TABLE entity_revision ADD content LONGTEXT NULL;`)
+  await db.runSql(
+    `ALTER TABLE entity_revision ADD meta_title VARCHAR(255) NULL;`,
+  )
+  await db.runSql(`ALTER TABLE entity_revision ADD meta_description TEXT NULL;`)
+  await db.runSql(`ALTER TABLE entity_revision ADD title VARCHAR(255) NULL;`)
+  await db.runSql(`ALTER TABLE entity_revision ADD url TEXT NULL;`)
+  await db.runSql(`ALTER TABLE entity_revision ADD changes TEXT NULL;`)
+  console.log('end altering table')
+
+  let count = 0
+
+  while (true) {
+    interface Row {
+      revisionId: number
+      params: Record<string, string | null>
+    }
+
+    console.log({ count })
+    const rows = await db.runSql<Row[]>(
+      `
+        select
+          entity_revision_id as revisionId,
+          JSON_OBJECTAGG(field, value) as params
+        from entity_revision_field
+        group by entity_revision_field.entity_revision_id
+        order by revisionId
+        limit 1000 offset ?
+      `,
+      count,
+    )
+
+    for (const { revisionId, params } of rows) {
+      await db.runSql(
+        `
+          update entity_revision
+            set content = ?, meta_title = ?, title = ?,
+                meta_description = ?, changes = ?, url = ?
+            where id = ?
+        `,
+        [
+          params['content'] ?? null,
+          params['meta_title'] ?? null,
+          params['title'] ?? null,
+          params['meta_description'] ?? params['description'] ?? null,
+          params['reasoning'] ?? params['Changes'] ?? null,
+          params['url'] ?? null,
+          revisionId,
+        ],
+      )
+    }
+
+    if (rows.length === 0) break
+    count += rows.length
+  }
+
+  console.log('dropping entity_revision_field table')
+  await db.dropTable('entity_revision_field')
+
+  await logger.closeAndSend()
+  // To reduce the time between deleting the keys and finishing the DB
+  // transaction, this should be the last command
+  await apiCache.deleteKeysAndQuit()
+}

--- a/src/20240506145600-merge-course-pages-into-courses.ts
+++ b/src/20240506145600-merge-course-pages-into-courses.ts
@@ -1,0 +1,721 @@
+import assert from 'assert'
+import { v4 as uuidv4 } from 'uuid'
+import { zip } from 'fp-ts/Array'
+import * as t from 'io-ts'
+
+import { ApiCache, Database, SlackLogger } from './utils'
+
+export async function up(db: Database) {
+  const apiCache = new ApiCache()
+  const logger = new SlackLogger(
+    '20240506145600-merge-course-pages-into-courses',
+  )
+
+  const batchSize = 5000
+  let entities: Row[] = []
+
+  do {
+    const lastUpdatedEntityId = entities.at(-1)?.entityId ?? 0
+
+    entities = await db.runSql<Row[]>(
+      `select
+           entity.id as entityId
+         from entity
+         join type on entity.type_id = type.id
+         where type.name in ("course")
+         and entity.id > ?
+         order by entity.id limit ?`,
+      lastUpdatedEntityId,
+      batchSize,
+    )
+
+    for (const entity of entities) {
+      await updateExerciseGroup(db, apiCache, entity.entityId, logger)
+    }
+  } while (entities.length > 0)
+
+  apiCache.deleteUnrevisedRevisions()
+  await logger.closeAndSend()
+  // To reduce the time between deleting the keys and finishing the DB
+  // transaction, this should be the last command
+  await apiCache.deleteKeysAndQuit()
+
+  interface Row {
+    entityId: number
+  }
+}
+
+const ChildContentDecoder = t.intersection([
+  t.type({
+    content: t.type({
+      plugin: t.literal('rows'),
+    }),
+  }),
+  t.partial({
+    title: t.string,
+    id: t.string,
+  }),
+])
+const ParentContentDecoder = t.type({
+  plugin: t.literal('course'),
+  state: t.record(t.string, t.unknown),
+})
+const RowPluginDecoder = t.type({ plugin: t.literal('rows') })
+const TextPluginDecoder = t.type({ plugin: t.literal('text') })
+
+async function updateExerciseGroup(
+  db: Database,
+  apiCache: ApiCache,
+  parentId: number,
+  logger: SlackLogger,
+) {
+  // Load the tree of the parent entity. It is either only the parent (without the
+  // solution / without any children):
+  //
+  //    [ parent ]
+  //
+  // or it is a parent with children:
+  //
+  //    [ parent ]
+  //      └ [ child1 ]
+  //      └ [ child2 ]
+  //
+  // The list of revisions are stored next to the entity in the node:
+  //
+  //    [ parent ]:      [ e1, e2, e3, ...]
+  //      └ [ child1 ]   [ s1, s2, s3, ...]
+  const parentNode = await loadEntityNode(db, parentId)
+
+  for (const child of parentNode.children) {
+    assert(child.children.length === 0, 'child must not have children')
+  }
+
+  // If a parent does not have any revision, there is no transformation possible.
+  // Even if the child(solution / exercise / course-page) has revisions.
+  if (parentNode.value.revisions.length === 0) {
+    console.log(`Warning: Parent (${parentId}) has no revision`)
+    return
+  }
+
+  // From the tree of revisions we calculate the list of overall edits. We
+  // represent an edit as a tree with the
+  // same structure as the parent. The value for parent / child is
+  // a revision (type `EntityWithRevision`) if the parent / child was
+  // edited or `null` when it was not edited. So let's assume the entity
+  // tree with the revisions has the structure
+  //
+  //    [ parent ]       [ edit_on_date1 | edit_on_date2 ]
+  //      └ [ child1 ]   [ edit_on_date1 | edit_on_date3 ]
+  //
+  // Then the list of edits is
+  //
+  // [ edit_on_date1 ]     | [ edit_on_date2 ] | [ null ]
+  //   └ [ edit_on_date2 ] |   └ [ null ]      |   └ [ edit_on_date3 ]
+  const edits = getEdits(parentNode)
+
+  if (edits.length > 0 && edits[0].value == null) {
+    console.log(
+      `Warning: Parent entity ${parentId} has a revision for a child before its first revision`,
+    )
+  }
+
+  // When one child has a revision before the parent we use the first
+  // revision of the parent as the fallback content
+  const fallbackParent = edits.filter((r) => r.value != null).at(0)
+
+  assert(
+    fallbackParent?.value != null,
+    `Illegal state: Parent entity ${parentId} has no content`,
+  )
+
+  // Here we store the current version of the parent after each edit. We
+  // start with everything is null.
+  let currentVersion: TreeNode<EntityWithRevision | null> = mapTree(
+    () => null,
+    parentNode,
+  )
+
+  for (const edit of edits) {
+    // Add the edit to the current version
+    currentVersion = concatTree(
+      (a, b) => (b == null ? a : b),
+      currentVersion,
+      edit,
+    )
+
+    const currentParent = currentVersion.value ?? fallbackParent.value
+    // Current children of this edit while we only take those
+    // children which have at least one revision
+    const currentChildren = currentVersion.children.filter(hasNonEmptyRevision)
+
+    let parentContent = JSON.parse(
+      currentParent?.revision?.content ??
+        JSON.stringify({ plugin: 'rows', state: [] }),
+    ) as unknown
+
+    // Should not happen with our fallback...
+    assert(parentContent != null, 'Illegal state: Parent is null')
+
+    if (TextPluginDecoder.is(parentContent)) {
+      parentContent = { plugin: 'rows', state: [parentContent], id: uuidv4() }
+    }
+
+    if (RowPluginDecoder.is(parentContent)) {
+      parentContent = {
+        plugin: 'course',
+        state: { content: parentContent },
+        id: uuidv4(),
+      }
+    }
+
+    if (!ParentContentDecoder.is(parentContent)) {
+      console.log({ parentContent })
+
+      throw new Error(
+        `Illegal content for parent entity ${parentId} with current revision ${currentParent.revision.id}`,
+      )
+    }
+
+    // Do not update a migrated parent again
+    if (parentContent.state.pages != null) continue
+
+    const childrenContent = currentChildren.map((node) => {
+      const value = node.value
+      let content = JSON.parse(value.revision.content)
+      const id = `${value.id}-course-page`
+
+      if ('cells' in content) {
+        console.warn(
+          `Splish content found for child ${value.id} with current revision ${value.revision.id}`,
+        )
+
+        content = {
+          plugin: 'rows',
+          state: [
+            {
+              plugin: 'unsupported',
+              state: {
+                plugin: 'splishContent',
+                state: content,
+              },
+              id: uuidv4(),
+            },
+          ],
+          id: uuidv4(),
+        }
+      }
+
+      if (RowPluginDecoder.is(content)) {
+        content = { content }
+      }
+
+      content.id = id
+
+      if (!ChildContentDecoder.is(content)) {
+        console.log({ content: JSON.stringify(content, undefined, 2) })
+        throw new Error(
+          `Illegal content for child ${value.id} with current revision ${value.revision.id}`,
+        )
+      }
+
+      content.title = value.revision.title ?? `Course page ${value.id}`
+      // Uncomment when license need to be updated as well
+      /*
+      if (currentParent.licenseId !== value.licenseId) {
+        content.state['licenseId'] = value.licenseId
+      }
+      */
+
+      return content
+    })
+
+    parentContent.state['pages'] = childrenContent
+
+    const newContent = JSON.stringify(parentContent)
+
+    if (edit.value != null) {
+      // In this edit a parent revision was added -> We can change the
+      // content of it
+
+      await updateEntityRevisionField({
+        db,
+        revisionId: edit.value.revision.id,
+        field: 'content',
+        value: newContent,
+      })
+
+      logger.logEvent('changeParentContent', {
+        entityId: edit.value.id,
+        revisionId: edit.value.revision.id,
+        oldContent: edit.value.revision.content,
+        newContent,
+      })
+
+      apiCache.markUuid(edit.value.revision.id)
+    } else {
+      // In this edit the parent was not changed -> Let's use the revision
+      // of one changed child and change it to a revision of the parent
+      const revisionToOvertake = getValues(edit).filter(isNotNull).at(0)
+
+      // This should not happen
+      assert(revisionToOvertake !== undefined)
+
+      await migrate(
+        db,
+        ` update entity_revision set repository_id = ?
+          where id = ?`,
+        parentId,
+        revisionToOvertake.revision.id,
+      )
+
+      if (currentParent.revision.title != null) {
+        await updateEntityRevisionField({
+          db,
+          revisionId: revisionToOvertake.revision.id,
+          field: 'title',
+          value: currentParent.revision.title,
+        })
+      }
+
+      if (currentParent.revision.description != null) {
+        await updateEntityRevisionField({
+          db,
+          revisionId: revisionToOvertake.revision.id,
+          field: 'meta_description',
+          value: currentParent.revision.description,
+        })
+      }
+
+      for (const child of parentNode.children) {
+        // We need to update the current revision of the child -> Otherwise
+        // staging would try to load the revision which results in an error
+        if (child.value.currentRevisionId === revisionToOvertake.revision.id) {
+          await migrate(
+            db,
+            ` update entity set current_revision_id = NULL
+            where id = ?`,
+            child.value.id,
+          )
+
+          logger.logEvent('currentRevisionSetToNull', {
+            entityId: child.value.id,
+          })
+
+          // Update the current revision of the parent since we know that
+          // we have added a new revision to the child which was already
+          // reviewed
+          await updateCurrentRevisionOfEntity({
+            db,
+            apiCache,
+            parent: parentNode.value,
+            child: child.value,
+            logger,
+          })
+
+          apiCache.markUuid(child.value.id)
+        }
+      }
+
+      await updateEntityRevisionField({
+        db,
+        revisionId: revisionToOvertake.revision.id,
+        field: 'content',
+        value: newContent,
+      })
+
+      logger.logEvent('overtakeChildContent', {
+        revisionToOvertake,
+        newContent,
+      })
+
+      apiCache.markUuid(revisionToOvertake.revision.id)
+    }
+  }
+
+  apiCache.markUuid(parentNode.value.id)
+
+  for (const child of parentNode.children) {
+    await moveCommentsFromChildToParent({
+      db,
+      apiCache,
+      parent: parentNode.value,
+      child: child.value,
+    })
+
+    apiCache.markUuid(child.value.id)
+  }
+}
+
+async function updateEntityRevisionField({
+  db,
+  revisionId,
+  field,
+  value,
+}: {
+  db: Database
+  revisionId: number
+  field: string
+  value: string
+}) {
+  const { affectedRows } = await db.runSql<{ affectedRows: number }>(
+    ` update entity_revision set ${field} = ?
+          where id = ?`,
+    value,
+    revisionId,
+  )
+
+  if (affectedRows === 0) {
+    await db.runSql(
+      `insert into entity_revision
+          (entity_revision_id, ?)
+          values (?, ?)`,
+      field,
+      revisionId,
+      value,
+    )
+  }
+}
+
+async function updateCurrentRevisionOfEntity({
+  db,
+  apiCache,
+  parent,
+  child,
+  logger,
+}: {
+  db: Database
+  apiCache: ApiCache
+  parent: EntityBase
+  child: EntityBase
+  logger: SlackLogger
+}) {
+  if (
+    child.currentRevisionId != null &&
+    child.currentRevisionId > (parent.currentRevisionId ?? 0)
+  ) {
+    await db.runSql(
+      `update entity set current_revision_id = ? where id = ?`,
+      child.currentRevisionId,
+      parent.id,
+    )
+
+    logger.logEvent('currentRevisionChanged', {
+      entityId: parent.id,
+      currentRevision: {
+        old: parent.currentRevisionId,
+        new: child.currentRevisionId,
+      },
+    })
+
+    apiCache.markUuid(parent.id)
+  }
+}
+
+async function moveCommentsFromChildToParent({
+  db,
+  apiCache,
+  parent,
+  child,
+}: {
+  db: Database
+  apiCache: ApiCache
+  parent: EntityBase
+  child: EntityBase
+}) {
+  const commentsOfSolution = await db.runSql<{ id: number }[]>(
+    `select id from comment where uuid_id = ?`,
+    child.id,
+  )
+
+  await db.runSql(
+    `update comment set uuid_id = ? where uuid_id = ?`,
+    parent.id,
+    child.id,
+  )
+
+  for (const comment of commentsOfSolution) {
+    apiCache.markUuid(comment.id)
+  }
+
+  apiCache.deleteThreadIds(parent.id)
+  apiCache.deleteThreadIds(child.id)
+}
+
+/**
+ * Returns list of all edits by the following algorithm:
+ *
+ *    while (there are still revisions in the parent its children) {
+ *      // 1. Take the min date of all revisions
+ *
+ *      // 2. For parent and children split the first revision from it's
+ *      //    list of revisions if it's date is less than minDate + 10 seconds
+ *    }
+ */
+function getEdits(
+  entity: TreeNode<EntityWithRevisions>,
+): TreeNode<EntityWithRevision | null>[] {
+  let remainingRevisions = entity
+  let edits: TreeNode<EntityWithRevision | null>[] = []
+
+  while (
+    getValues(remainingRevisions).some((entity) => entity.revisions.length > 0)
+  ) {
+    const firstDates = getValues(remainingRevisions)
+      .map((entity) => entity.revisions.at(0)?.date ?? null)
+      .filter(isNotNull)
+    const minDate = firstDates.reduce((a, b) => (a <= b ? a : b))
+
+    const nextEdit = splitNextEdit(remainingRevisions, minDate)
+
+    edits.push(nextEdit.nextEdit)
+
+    remainingRevisions = nextEdit.remainingRevisions
+  }
+
+  return edits
+}
+
+function splitNextEdit(
+  node: TreeNode<EntityWithRevisions>,
+  date: Date,
+): {
+  nextEdit: TreeNode<EntityWithRevision | null>
+  remainingRevisions: TreeNode<EntityWithRevisions>
+} {
+  let nextEditRevision: EntityWithRevision | null
+  let remainingRevisions: EntityWithRevisions
+
+  if (
+    node.value.revisions.length > 0 &&
+    node.value.revisions[0].date.getTime() < date.getTime() + 10 * 1000
+  ) {
+    const base = {
+      id: node.value.id,
+      licenseId: node.value.licenseId,
+      typeName: node.value.typeName,
+      currentRevisionId: node.value.currentRevisionId,
+    }
+    nextEditRevision = { ...base, revision: node.value.revisions[0] }
+    remainingRevisions = { ...base, revisions: node.value.revisions.slice(1) }
+  } else {
+    nextEditRevision = null
+    remainingRevisions = node.value
+  }
+
+  const children = node.children.map((child) => splitNextEdit(child, date))
+  const nextEditChildren = children.map((x) => x.nextEdit)
+  const remainingRevisionsChildren = children.map((x) => x.remainingRevisions)
+
+  return {
+    nextEdit: { value: nextEditRevision, children: nextEditChildren },
+    remainingRevisions: {
+      value: remainingRevisions,
+      children: remainingRevisionsChildren,
+    },
+  }
+}
+
+async function loadEntityNode(
+  db: Database,
+  entityId: number,
+): Promise<TreeNode<EntityWithRevisions>> {
+  const entity = await loadEntity(db, entityId)
+  let childIds: number[] = []
+
+  if (entity.typeName === TypeName.Course) {
+    childIds = await loadEntityChildrenIds({
+      db,
+      entityId: entityId,
+      childType: TypeName.CoursePage,
+    })
+  }
+
+  const children = await Promise.all(
+    childIds.map((childId) => loadEntityNode(db, childId)),
+  )
+
+  return { value: entity, children }
+}
+
+async function loadEntityChildrenIds({
+  db,
+  entityId,
+  childType,
+  limit,
+}: {
+  db: Database
+  entityId: number
+  childType: TypeName
+  limit?: number
+}): Promise<number[]> {
+  let sqlCommand = `
+      select entity_link.child_id as childId
+      from entity_link
+      join entity child on child.id = entity_link.child_id
+      join type child_type on child_type.id = child.type_id
+      join uuid child_uuid on child_uuid.id = child.id
+      where
+        entity_link.parent_id = ? and child_type.name = ?
+        and child_uuid.trashed = 0
+      order by entity_link.order ASC`
+
+  if (limit != null) {
+    sqlCommand += ` limit ${limit}`
+  }
+
+  const result = await db.runSql<{ childId: number }[]>(
+    sqlCommand,
+    entityId,
+    childType,
+  )
+
+  return result.map((row) => row.childId)
+}
+
+async function loadEntity(
+  db: Database,
+  entityId: number,
+): Promise<EntityWithRevisions> {
+  const entityBaseResult = await db.runSql<EntityBase[]>(
+    ` select
+        entity.id as id,
+        entity.license_id as licenseId,
+        entity.current_revision_id as currentRevisionId,
+        type.name as typeName
+      from entity
+      join type on entity.type_id = type.id
+      where entity.id = ?`,
+    entityId,
+  )
+  const entityBase = pickSingleton(entityBaseResult)
+
+  assert(
+    isTypeName(entityBase.typeName),
+    `Entity ${entityId} has unsupported type name`,
+  )
+
+  const revisions = await loadRevisions(db, entityId)
+
+  return { ...entityBase, revisions }
+}
+
+async function loadRevisions(
+  db: Database,
+  entityId: number,
+): Promise<Revision[]> {
+  return await db.runSql<Revision[]>(
+    ` select
+          entity_revision.id,
+          entity_revision.date,
+          content,
+          title,
+          meta_description as description
+      from entity_revision
+      where entity_revision.repository_id = ?
+      order by entity_revision.date`,
+    entityId,
+  )
+}
+
+function hasNonEmptyRevision(
+  node: TreeNode<EntityWithRevision | null>,
+): node is TreeNode<EntityWithRevision> {
+  if (node.value == null) return false
+
+  const content = node.value.revision.content
+
+  return content != null && content !== ''
+}
+
+/**
+ * Lifts a function from the value of the tree to the tree itself. Similar to
+ * how `map` is defined for lists.
+ */
+function mapTree<A, B>(mapper: (x: A) => B, node: TreeNode<A>): TreeNode<B> {
+  return {
+    value: mapper(node.value),
+    children: node.children.map((child) => mapTree(mapper, child)),
+  }
+}
+
+/**
+ * Lifts an operation on the value of a tree to the tree itself. When `concat`
+ * for example is an operation on a type `A`, then `concatTree` can be used
+ * to get an operation on `TreeNode<A>` by applying `concat` to all values.
+ * Thereby we check that both trees have the same structure.
+ */
+function concatTree<A>(
+  concat: (x: A, y: A) => A,
+  x: TreeNode<A>,
+  y: TreeNode<A>,
+): TreeNode<A> {
+  // In our case the structure of both trees should always be the same.
+  assert(
+    x.children.length === y.children.length,
+    'Illegal state: Both nodes should have the same number of children.',
+  )
+
+  return {
+    value: concat(x.value, y.value),
+    children: zip(x.children, y.children).map(([x, y]) =>
+      concatTree(concat, x, y),
+    ),
+  }
+}
+
+function getValues<V>(node: TreeNode<V>): V[] {
+  return [node.value, ...node.children.flatMap(getValues)]
+}
+
+function pickSingleton<A>(elements: A[]): A {
+  assert(elements.length === 1, 'List has more than one element')
+
+  return elements[0]
+}
+
+interface TreeNode<ValueType> {
+  value: ValueType
+  children: TreeNode<ValueType>[]
+}
+
+interface EntityWithRevisions extends EntityBase {
+  revisions: Revision[]
+}
+
+interface EntityWithRevision extends EntityBase {
+  revision: Revision
+}
+
+interface Revision {
+  id: number
+  date: Date
+  content: string
+  title: string | null
+  description: string | null
+}
+
+interface EntityBase {
+  id: number
+  licenseId: number
+  currentRevisionId: number | null
+  typeName: TypeName
+}
+
+enum TypeName {
+  Course = 'course',
+  CoursePage = 'course-page',
+}
+
+function isTypeName(values: string): values is TypeName {
+  return Object.values<string>(TypeName).includes(values)
+}
+
+function isNotNull<A>(value: A | null): value is A {
+  return value != null
+}
+
+// I added this function so that I can easily outcomment all mutations in order
+// to avoid a rollback of the DB. -- Kulla
+async function migrate(db: Database, sql: string, ...args: unknown[]) {
+  await db.runSql(sql, ...args)
+}

--- a/src/20240607193000-simplification-event-of-tables.ts
+++ b/src/20240607193000-simplification-event-of-tables.ts
@@ -1,0 +1,355 @@
+import * as t from 'io-ts'
+
+import { ApiCache, Database, SlackLogger } from './utils'
+
+export async function up(db: Database) {
+  const apiCache = new ApiCache()
+  const logger = new SlackLogger(
+    '20240607193000-simplification-event-of-tables',
+  )
+
+  console.log(
+    'Starting migration 20240607193000-simplification-event-of-tables',
+  )
+
+  for (const columnName of ['uuid_parameter', 'uuid_parameter2']) {
+    await db.runSql(`ALTER TABLE event_log ADD ${columnName} BIGINT NULL;`)
+    await db.runSql(
+      `CREATE INDEX idx_event_${columnName} ON event_log (${columnName});`,
+    )
+    await db.runSql(`
+      ALTER TABLE event_log
+      ADD CONSTRAINT fk_event_${columnName}
+      FOREIGN KEY (${columnName})
+      REFERENCES uuid(id)
+      ON DELETE CASCADE ON UPDATE CASCADE;
+    `)
+    console.log(`Column ${columnName} added to event_log`)
+  }
+  await db.runSql('ALTER TABLE event_log ADD string_parameter MEDIUMTEXT NULL;')
+  console.log('Column string_parameter added to event_log')
+
+  await updateEventTable(db, logger)
+
+  await db.runSql('ALTER TABLE event RENAME TO event_type;')
+  await db.runSql(
+    'ALTER TABLE event_log RENAME COLUMN event_id TO event_type_id;',
+  )
+  console.log('Table event renamed to event_type')
+
+  await db.runSql('alter table event_log rename to event')
+  await db.runSql(
+    'alter table notification_event rename column event_log_id to event_id',
+  )
+  console.log('Table event_log renamed to event')
+
+  // TODO: Log those tables before dropping them
+  await db.runSql('drop table event_parameter_string')
+  await db.runSql('drop table event_parameter_uuid')
+  await db.runSql('drop table event_parameter')
+  await db.runSql('drop table event_parameter_name')
+
+  await logger.closeAndSend()
+  // To reduce the time between deleting the keys and finishing the DB
+  // transaction, this should be the last command
+  await apiCache.deleteKeysAndQuit()
+}
+
+enum EventType {
+  ArchiveThread = 'discussion/comment/archive',
+  RestoreThread = 'discussion/restore',
+  CreateComment = 'discussion/comment/create',
+  CreateThread = 'discussion/create',
+  CreateEntity = 'entity/create',
+  SetLicense = 'license/object/set',
+  CreateEntityLink = 'entity/link/create',
+  RemoveEntityLink = 'entity/link/remove',
+  CreateEntityRevision = 'entity/revision/add',
+  CheckoutRevision = 'entity/revision/checkout',
+  RejectRevision = 'entity/revision/reject',
+  CreateTaxonomyLink = 'taxonomy/term/associate',
+  RemoveTaxonomyLink = 'taxonomy/term/dissociate',
+  CreateTaxonomyTerm = 'taxonomy/term/create',
+  SetTaxonomyTerm = 'taxonomy/term/update',
+  SetTaxonomyParent = 'taxonomy/term/parent/change',
+  RestoreUuid = 'uuid/restore',
+  TrashUuid = 'uuid/trash',
+}
+
+const DatabaseEventRepresentations = {
+  ArchiveThread: getDatabaseRepresentationDecoder({
+    type: EventType.ArchiveThread,
+    uuidParameters: t.type({}),
+    stringParameters: t.type({}),
+  }),
+  RestoreThread: getDatabaseRepresentationDecoder({
+    type: EventType.RestoreThread,
+    uuidParameters: t.type({}),
+    stringParameters: t.type({}),
+  }),
+  CreateComment: getDatabaseRepresentationDecoder({
+    type: EventType.CreateComment,
+    uuidParameters: t.type({ discussion: t.number }),
+    stringParameters: t.type({}),
+  }),
+  CreateThread: getDatabaseRepresentationDecoder({
+    type: EventType.CreateThread,
+    uuidParameters: t.type({ on: t.number }),
+    stringParameters: t.type({}),
+  }),
+  CreateEntity: getDatabaseRepresentationDecoder({
+    type: EventType.CreateEntity,
+    uuidParameters: t.type({}),
+    stringParameters: t.type({}),
+  }),
+  SetLicense: getDatabaseRepresentationDecoder({
+    type: EventType.SetLicense,
+    uuidParameters: t.type({}),
+    stringParameters: t.type({}),
+  }),
+  CreateEntityLink: getDatabaseRepresentationDecoder({
+    type: EventType.CreateEntityLink,
+    uuidParameters: t.type({ parent: t.number }),
+    stringParameters: t.type({}),
+  }),
+  RemoveEntityLink: getDatabaseRepresentationDecoder({
+    type: EventType.RemoveEntityLink,
+    uuidParameters: t.type({ parent: t.number }),
+    stringParameters: t.type({}),
+  }),
+  CreateEntityRevision: getDatabaseRepresentationDecoder({
+    type: EventType.CreateEntityRevision,
+    uuidParameters: t.type({ repository: t.number }),
+    stringParameters: t.type({}),
+  }),
+  CheckoutRevision: getDatabaseRepresentationDecoder({
+    type: EventType.CheckoutRevision,
+    uuidParameters: t.type({ repository: t.number }),
+    stringParameters: t.type({ reason: t.string }),
+  }),
+  RejectRevision: getDatabaseRepresentationDecoder({
+    type: EventType.RejectRevision,
+    uuidParameters: t.type({ repository: t.number }),
+    stringParameters: t.type({ reason: t.string }),
+  }),
+  CreateTaxonomyLink: getDatabaseRepresentationDecoder({
+    type: EventType.CreateTaxonomyLink,
+    uuidParameters: t.type({ object: t.number }),
+    stringParameters: t.type({}),
+  }),
+  RemoveTaxonomyLink: getDatabaseRepresentationDecoder({
+    type: EventType.RemoveTaxonomyLink,
+    uuidParameters: t.type({ object: t.number }),
+    stringParameters: t.type({}),
+  }),
+  CreateTaxonomyTerm: getDatabaseRepresentationDecoder({
+    type: EventType.CreateTaxonomyTerm,
+    uuidParameters: t.type({}),
+    stringParameters: t.type({}),
+  }),
+  SetTaxonomyTerm: getDatabaseRepresentationDecoder({
+    type: EventType.SetTaxonomyTerm,
+    uuidParameters: t.type({}),
+    stringParameters: t.type({}),
+  }),
+  SetTaxonomyParent: getDatabaseRepresentationDecoder({
+    type: EventType.SetTaxonomyParent,
+    uuidParameters: t.type({
+      from: t.union([t.number, t.null]),
+      to: t.union([t.number, t.null]),
+    }),
+    stringParameters: t.type({}),
+  }),
+  TrashUuid: getDatabaseRepresentationDecoder({
+    type: EventType.TrashUuid,
+    uuidParameters: t.type({}),
+    stringParameters: t.type({}),
+  }),
+  RestoreUuid: getDatabaseRepresentationDecoder({
+    type: EventType.RestoreUuid,
+    uuidParameters: t.type({}),
+    stringParameters: t.type({}),
+  }),
+} as const
+
+type DatabaseEventRepresentation = {
+  [P in keyof typeof DatabaseEventRepresentations]: t.TypeOf<
+    (typeof DatabaseEventRepresentations)[P]
+  >
+}[keyof typeof DatabaseEventRepresentations]
+
+const DatabaseEventRepresentation: t.Type<DatabaseEventRepresentation> =
+  t.union([
+    DatabaseEventRepresentations.ArchiveThread,
+    DatabaseEventRepresentations.CheckoutRevision,
+    DatabaseEventRepresentations.CreateComment,
+    DatabaseEventRepresentations.CreateEntity,
+    DatabaseEventRepresentations.CreateEntityLink,
+    DatabaseEventRepresentations.CreateEntityRevision,
+    DatabaseEventRepresentations.CreateTaxonomyTerm,
+    DatabaseEventRepresentations.CreateTaxonomyLink,
+    DatabaseEventRepresentations.CreateThread,
+    DatabaseEventRepresentations.RejectRevision,
+    DatabaseEventRepresentations.RemoveEntityLink,
+    DatabaseEventRepresentations.RemoveTaxonomyLink,
+    DatabaseEventRepresentations.RestoreThread,
+    DatabaseEventRepresentations.RestoreUuid,
+    DatabaseEventRepresentations.SetLicense,
+    DatabaseEventRepresentations.SetTaxonomyParent,
+    DatabaseEventRepresentations.SetTaxonomyTerm,
+    DatabaseEventRepresentations.TrashUuid,
+  ])
+
+async function updateEventTable(db: Database, logger: SlackLogger) {
+  interface Row {
+    id: number
+  }
+
+  const batchSize = 1000
+  let offset = 0
+  let rows: Row[] = []
+
+  console.log('Updating event table')
+
+  while (true) {
+    console.log(`Processing rows from ${offset} to ${offset + batchSize}`)
+    rows = await db.runSql<Row[]>(
+      `
+        select
+          event_log.id as id,
+          event.name as type,
+          JSON_OBJECTAGG(
+            COALESCE(event_parameter_name.name, "__unused"),
+            event_parameter_uuid.uuid_id
+          ) as uuidParameters,
+          JSON_OBJECTAGG(
+            COALESCE(event_parameter_name.name, "__unused"),
+            event_parameter_string.value
+          ) as stringParameters
+        from event_log
+        join event on event_log.event_id = event.id
+        left join event_parameter on event_parameter.log_id = event_log.id
+        left join event_parameter_name on event_parameter.name_id = event_parameter_name.id
+        left join event_parameter_string on event_parameter_string.event_parameter_id = event_parameter.id
+        left join event_parameter_uuid on event_parameter_uuid.event_parameter_id = event_parameter.id
+        group by event_log.id
+        order by id
+        limit ? offset ?
+      `,
+      batchSize,
+      offset,
+    )
+
+    for (const row of rows) {
+      if (DatabaseEventRepresentation.is(row)) {
+        const newData = toNewData(row)
+
+        await db.runSql(
+          `
+            update event_log
+            set uuid_parameter = ?,
+                uuid_parameter2 = ?,
+                string_parameter = ?
+            where id = ?
+          `,
+          newData.uuidParameter,
+          newData.uuidParameter2,
+          newData.stringParameter,
+          row.id,
+        )
+      } else {
+        // This event is malformed => let's ignore it
+        logger.logEvent('malformedEventFound', { event: row })
+        console.log('Malformed event found', row)
+      }
+    }
+
+    if (rows.length === 0) {
+      break
+    }
+
+    offset += rows.length
+  }
+
+  console.log('Event table updated')
+}
+
+// Update event table row based on event type
+function toNewData(row: DatabaseEventRepresentation) {
+  const base: NewData = {
+    uuidParameter: null,
+    uuidParameter2: null,
+    stringParameter: null,
+  }
+
+  switch (row.type) {
+    case EventType.ArchiveThread:
+    case EventType.RestoreThread:
+    case EventType.CreateEntity:
+    case EventType.SetLicense:
+    case EventType.CreateTaxonomyTerm:
+    case EventType.SetTaxonomyTerm:
+    case EventType.TrashUuid:
+    case EventType.RestoreUuid:
+      return base
+    case EventType.CreateComment:
+      return { ...base, uuidParameter: row.uuidParameters.discussion }
+    case EventType.CreateThread:
+      return { ...base, uuidParameter: row.uuidParameters.on }
+    case EventType.CreateEntityLink:
+      return { ...base, uuidParameter: row.uuidParameters.parent }
+    case EventType.RemoveEntityLink:
+      return { ...base, uuidParameter: row.uuidParameters.parent }
+    case EventType.CreateEntityRevision:
+      return { ...base, uuidParameter: row.uuidParameters.repository }
+    case EventType.CheckoutRevision:
+      return {
+        ...base,
+        uuidParameter: row.uuidParameters.repository,
+        stringParameter: row.stringParameters.reason,
+      }
+    case EventType.RejectRevision:
+      return {
+        ...base,
+        uuidParameter: row.uuidParameters.repository,
+        stringParameter: row.stringParameters.reason,
+      }
+    case EventType.CreateTaxonomyLink:
+      return { ...base, uuidParameter: row.uuidParameters.object }
+    case EventType.RemoveTaxonomyLink:
+      return { ...base, uuidParameter: row.uuidParameters.object }
+    case EventType.SetTaxonomyParent:
+      return {
+        ...base,
+        uuidParameter: row.uuidParameters.from,
+        uuidParameter2: row.uuidParameters.to,
+      }
+  }
+}
+
+interface NewData {
+  uuidParameter: number | null
+  uuidParameter2: number | null
+  stringParameter: string | null
+}
+
+function getDatabaseRepresentationDecoder<
+  Type extends EventType,
+  UuidParameters extends Record<string, number | null>,
+  StringParameters extends Record<string, string>,
+>({
+  type,
+  uuidParameters,
+  stringParameters,
+}: {
+  type: Type
+  uuidParameters: t.Type<UuidParameters>
+  stringParameters: t.Type<StringParameters>
+}) {
+  return t.type({
+    id: t.number,
+    type: t.literal(type),
+    uuidParameters: uuidParameters,
+    stringParameters: stringParameters,
+  })
+}

--- a/src/20240608121400-simplification-of-taxonomy-tables.ts
+++ b/src/20240608121400-simplification-of-taxonomy-tables.ts
@@ -1,0 +1,147 @@
+import { ApiCache, Database, SlackLogger } from './utils'
+
+export async function up(db: Database) {
+  const apiCache = new ApiCache()
+  const logger = new SlackLogger(
+    '20240608121400-simplification-of-taxonomy-tables',
+  )
+
+  await mergeTaxonomyTable(db)
+  await mergeTermTable(db)
+
+  await db.runSql(`ALTER TABLE term_taxonomy RENAME TO taxonomy`)
+
+  await logger.closeAndSend()
+  // To reduce the time between deleting the keys and finishing the DB
+  // transaction, this should be the last command
+  await apiCache.deleteKeysAndQuit()
+}
+
+async function mergeTaxonomyTable(db: Database) {
+  console.log('Adding type_id to term_taxonomy')
+
+  await db.runSql(`ALTER TABLE term_taxonomy ADD COLUMN type_id INT`)
+  await db.runSql(`
+    ALTER TABLE term_taxonomy ADD CONSTRAINT fk_taxonomy_type
+    FOREIGN KEY (type_id) REFERENCES type(id)
+    ON DELETE CASCADE ON UPDATE CASCADE
+  `)
+
+  interface Row {
+    id: number
+    typeId: number | null
+  }
+
+  const batchSize = 1000
+  let offset = 0
+  let rows: Row[] = []
+
+  while (true) {
+    console.log(`Fetching rows from ${offset} to ${offset + batchSize}`)
+    rows = await db.runSql(
+      `SELECT
+        term_taxonomy.id AS id,
+        taxonomy.type_id AS typeId
+      FROM term_taxonomy
+      LEFT JOIN taxonomy ON term_taxonomy.taxonomy_id = taxonomy.id
+      ORDER BY term_taxonomy.id
+      LIMIT ? OFFSET ?`,
+      batchSize,
+      offset,
+    )
+
+    if (rows.length === 0) {
+      break
+    }
+
+    for (const row of rows) {
+      if (row.typeId === null) {
+        throw new Error(`No type found for taxonomy ${row.id}`)
+      }
+
+      await db.runSql(
+        `UPDATE term_taxonomy SET type_id = ? WHERE id = ?`,
+        row.typeId,
+        row.id,
+      )
+    }
+
+    offset += batchSize
+  }
+
+  console.log('Dropping taxonomy table')
+  await db.runSql(
+    'ALTER TABLE term_taxonomy DROP FOREIGN KEY fk_term_taxonomy_taxonomy1;',
+  )
+  await db.runSql(`ALTER TABLE term_taxonomy DROP COLUMN taxonomy_id`)
+  await db.runSql(`DROP TABLE taxonomy`)
+}
+
+async function mergeTermTable(db: Database) {
+  console.log('Adding name and instance_id to term_taxonomy')
+
+  await db.runSql(`ALTER TABLE term_taxonomy ADD COLUMN instance_id INT`)
+  await db.runSql(`ALTER TABLE term_taxonomy ADD COLUMN name varchar(255)`)
+  await db.runSql(`
+    ALTER TABLE term_taxonomy ADD CONSTRAINT fk_taxonomy_instance
+    FOREIGN KEY (instance_id) REFERENCES instance(id)
+    ON DELETE CASCADE ON UPDATE CASCADE
+  `)
+
+  interface Row {
+    id: number
+    instanceId: number | null
+    name: string | null
+  }
+
+  const batchSize = 1000
+  let offset = 0
+  let rows: Row[] = []
+
+  while (true) {
+    console.log(`Fetching rows from ${offset} to ${offset + batchSize}`)
+    rows = await db.runSql(
+      `SELECT
+        term_taxonomy.id AS id,
+        term.name AS name,
+        term.instance_id AS instanceId
+      FROM term_taxonomy
+      LEFT JOIN term ON term_taxonomy.term_id = term.id
+      ORDER BY term_taxonomy.id
+      LIMIT ? OFFSET ?`,
+      batchSize,
+      offset,
+    )
+
+    if (rows.length === 0) {
+      break
+    }
+
+    for (const row of rows) {
+      if (row.name === null || row.instanceId === null) {
+        throw new Error(
+          `IllegalState: No name / instance_id found for taxonomy ${row.id}`,
+        )
+      }
+
+      await db.runSql(
+        `UPDATE term_taxonomy SET instance_id = ?, name = ? WHERE id = ?`,
+        row.instanceId,
+        row.name,
+        row.id,
+      )
+    }
+
+    offset += batchSize
+  }
+
+  console.log('Dropping term table')
+  await db.runSql(
+    'ALTER TABLE term_taxonomy DROP INDEX uq_term_taxonomy_unique;',
+  )
+  await db.runSql(
+    'ALTER TABLE term_taxonomy DROP FOREIGN KEY fk_term_taxonomy_term1;',
+  )
+  await db.runSql(`ALTER TABLE term_taxonomy DROP COLUMN term_id`)
+  await db.runSql(`DROP TABLE term`)
+}


### PR DESCRIPTION
Fixes #346

## ToDo List

- [ ] Rename column `term_taxonomy_id` into `taxonomy_id` in `term_taxonomy_entity_link`
- [x] check whether frontend still needs the `taxonomyId` field, see https://serlo.github.io/unused-graphql-properties/#TaxonomyTerm.taxonomyId => I would like to delete it, since we delete the `taxonomy` table here.